### PR TITLE
Drop AMP, randomize background gif from a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ### Website
 
 - HTML Validation: https://validator.w3.org/nu/?doc=https%3A%2F%2Fwww.moistflap.com%2F
-- AMP Validation: https://validator.ampproject.org/#url=https%3A%2F%2Fwww.moistflap.com%2F
 - PageSpeed Insights: https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fwww.moistflap.com%2F&tab=mobile
 - WebPageTest: https://www.webpagetest.org/performance_optimization.php?test=210425_BiDcGZ_1db2a18b04313f1ca82a0a5647de2c1e&run=2#cache_static_content

--- a/index.html
+++ b/index.html
@@ -174,6 +174,50 @@
                 <dt>globule</dt>
                 <dd>A small round particle, especially of fat suspended in liquid.</dd>
             </div>
+            <div>
+                <dt>panties</dt>
+                <dd>Underwear for women or children. Consistently named one of the most-hated words in English, regardless of what it refers to.</dd>
+            </div>
+            <div>
+                <dt>slacks</dt>
+                <dd>Casual trousers, often pleated. Frequently disliked for reasons its detractors cannot quite articulate.</dd>
+            </div>
+            <div>
+                <dt>navel</dt>
+                <dd>The small indentation in the abdomen marking where the umbilical cord was once attached.</dd>
+            </div>
+            <div>
+                <dt>yolk</dt>
+                <dd>The yellow, spherical part of an egg, rich in fat and cholesterol.</dd>
+            </div>
+            <div>
+                <dt>gristle</dt>
+                <dd>Tough, rubbery cartilage found in cuts of meat, usually discovered mid-chew.</dd>
+            </div>
+            <div>
+                <dt>secretion</dt>
+                <dd>A substance produced and released by a cell, gland, or organ.</dd>
+            </div>
+            <div>
+                <dt>crusty</dt>
+                <dd>Having a hard, dry outer layer, often formed from something that was once wet.</dd>
+            </div>
+            <div>
+                <dt>bulbous</dt>
+                <dd>Round and swollen in shape, typically in an unflattering way.</dd>
+            </div>
+            <div>
+                <dt>spurt</dt>
+                <dd>A sudden, forceful burst of liquid from a small opening.</dd>
+            </div>
+            <div>
+                <dt>maggot</dt>
+                <dd>The legless larva of a fly, commonly found in decaying material.</dd>
+            </div>
+            <div>
+                <dt>nugget</dt>
+                <dd>A small, irregular lump, frequently breaded and fried.</dd>
+            </div>
         </dl>
 
         <p>There is no cure. Only community.</p>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" ⚡>
+<html lang="en">
 
 <head>
     <meta charset="utf-8">
@@ -9,9 +9,9 @@
     <meta name="keywords" content="moist,flap">
 
     <link rel="canonical" href="https://www.moistflap.com/">
-    <style amp-custom>
+    <style>
         body {
-            background-image: url(flap.gif);
+            background-image: url(flap.png);
             background-position: 50% 0;
             background-size: cover;
         }
@@ -29,9 +29,13 @@
             text-align: center;
         }
     </style>
-    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-    <script async src="https://cdn.ampproject.org/v0.js"></script>
-    <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+    <noscript>
+        <style>
+            body {
+                background-image: url(flap.gif);
+            }
+        </style>
+    </noscript>
 </head>
 
 <body>
@@ -39,24 +43,8 @@
         <h1>Moist Flap</h1>
     </main>
 
-    <amp-analytics type="gtag" data-credentials="include">
-        <script type="application/json">
-            {
-                "vars" : {
-                    "gtag_id": "UA-10469485-5",
-                    "config" : {
-                        "UA-10469485-5": { "groups": "default" }
-                    },
-                    "triggers": {
-                        "trackPageview": {
-                            "on": "visible",
-                            "request": "pageview"
-                        }
-                    }
-                }
-            }
-        </script>
-    </amp-analytics>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-10469485-5"></script>
+    <script src="main.js"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -3,35 +3,107 @@
 
 <head>
     <meta charset="utf-8">
-    <title>moist flap</title>
+    <title>Moist Flap — Word Aversion Support Group</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="flaps that are moist">
-    <meta name="keywords" content="moist,flap">
+    <meta name="description" content="A support group for people who suffer from word aversion. Do you suffer from word aversion?">
+    <meta name="keywords" content="moist,flap,word aversion,word aversion support group">
 
     <link rel="canonical" href="https://www.moistflap.com/">
     <style>
-        body {
-            background-image: url(flap.png);
-            background-position: 50% 0;
-            background-size: cover;
+        * {
+            box-sizing: border-box;
         }
 
-        h1 {
-            color: #fff;
+        body {
+            margin: 0;
             font-family: arial,
                 /* Windows, MacOS */
                 helvetica,
                 /* Unix+X, MacOS */
                 sans-serif;
+            color: #222;
+        }
+
+        #hero {
+            background-image: url(flap.png);
+            background-position: 50% 0;
+            background-size: cover;
+            background-repeat: no-repeat;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            padding: 20px;
+        }
+
+        #hero h1 {
+            color: #fff;
             font-size: 90px;
             font-weight: 900;
             text-shadow: 5px 5px 0 #222;
+            margin: 0;
+        }
+
+        #hero p {
+            color: #fff;
+            font-size: 28px;
+            font-weight: 700;
+            text-shadow: 2px 2px 0 #222;
+            margin: 10px 0 0;
+        }
+
+        main {
+            max-width: 680px;
+            margin: 0 auto;
+            padding: 50px 20px 80px;
+            line-height: 1.6;
+        }
+
+        main h2 {
             text-align: center;
+            font-size: 32px;
+        }
+
+        main>p {
+            text-align: center;
+            color: #555;
+        }
+
+        dl {
+            margin-top: 40px;
+        }
+
+        dl div {
+            margin-bottom: 24px;
+            padding-left: 16px;
+            border-left: 4px solid #1f7a8c;
+        }
+
+        dt {
+            font-weight: 900;
+            font-size: 22px;
+        }
+
+        dd {
+            margin: 4px 0 0;
+            color: #444;
+        }
+
+        @media (max-width: 600px) {
+            #hero h1 {
+                font-size: 56px;
+            }
+
+            #hero p {
+                font-size: 20px;
+            }
         }
     </style>
     <noscript>
         <style>
-            body {
+            #hero {
                 background-image: url(flap.gif);
             }
         </style>
@@ -39,8 +111,72 @@
 </head>
 
 <body>
-    <main id="main">
+    <header id="hero">
         <h1>Moist Flap</h1>
+        <p>Do you suffer from word aversion?</p>
+    </header>
+
+    <main>
+        <h2>Word Aversion Support Group</h2>
+        <p>
+            Word aversion is a real phenomenon: certain words trigger a
+            disproportionate feeling of disgust, completely unrelated to what
+            they mean. If any of the words below make your skin crawl,
+            congratulations &mdash; you are not alone.
+        </p>
+
+        <dl>
+            <div>
+                <dt>moist</dt>
+                <dd>Slightly wet. Consistently ranked the most-hated word in the English language.</dd>
+            </div>
+            <div>
+                <dt>flap</dt>
+                <dd>A flat piece attached on one side that hangs and moves freely. Also the unfortunate second half of this website's name.</dd>
+            </div>
+            <div>
+                <dt>phlegm</dt>
+                <dd>Thick mucus secreted in the respiratory passages, especially during a cold.</dd>
+            </div>
+            <div>
+                <dt>pus</dt>
+                <dd>A thick yellowish or greenish liquid produced in infected tissue.</dd>
+            </div>
+            <div>
+                <dt>ooze</dt>
+                <dd>To flow or seep out slowly, as through small openings.</dd>
+            </div>
+            <div>
+                <dt>fester</dt>
+                <dd>Of a wound: to become septic, swollen, and increasingly unpleasant.</dd>
+            </div>
+            <div>
+                <dt>smear</dt>
+                <dd>To spread something soft, sticky, or greasy across a surface.</dd>
+            </div>
+            <div>
+                <dt>curd</dt>
+                <dd>A soft, lumpy substance formed when milk coagulates.</dd>
+            </div>
+            <div>
+                <dt>gusset</dt>
+                <dd>A triangular piece of fabric sewn into a garment to strengthen or enlarge it.</dd>
+            </div>
+            <div>
+                <dt>crevice</dt>
+                <dd>A narrow opening or crack, especially in rock or skin.</dd>
+            </div>
+            <div>
+                <dt>squelch</dt>
+                <dd>To make a soft sucking sound, as of someone walking through mud.</dd>
+            </div>
+            <div>
+                <dt>globule</dt>
+                <dd>A small round particle, especially of fat suspended in liquid.</dd>
+            </div>
+        </dl>
+
+        <p>There is no cure. Only community.</p>
     </main>
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-10469485-5"></script>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,17 @@
+window.dataLayer = window.dataLayer || [];
+function gtag() {
+    dataLayer.push(arguments);
+}
+gtag('js', new Date());
+gtag('config', 'UA-10469485-5');
+
+var flaps = ['flap.gif', 'flap-rain.gif'];
+var pick = flaps[Math.floor(Math.random() * flaps.length)];
+var img = new Image();
+img.onload = function () {
+    document.body.style.backgroundImage = 'url(' + pick + ')';
+};
+img.onerror = function () {
+    document.body.style.backgroundImage = 'url(flap.gif)';
+};
+img.src = pick;

--- a/main.js
+++ b/main.js
@@ -5,13 +5,14 @@ function gtag() {
 gtag('js', new Date());
 gtag('config', 'UA-10469485-5');
 
+var hero = document.getElementById('hero');
 var flaps = ['flap.gif', 'flap-rain.gif'];
 var pick = flaps[Math.floor(Math.random() * flaps.length)];
 var img = new Image();
 img.onload = function () {
-    document.body.style.backgroundImage = 'url(' + pick + ')';
+    hero.style.backgroundImage = 'url(' + pick + ')';
 };
 img.onerror = function () {
-    document.body.style.backgroundImage = 'url(flap.gif)';
+    hero.style.backgroundImage = 'url(flap.gif)';
 };
 img.src = pick;

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -3,7 +3,7 @@
     "responseOverrides": {  },
     "globalHeaders": {
         "cache-control": "must-revalidate, max-age=604800",
-        "content-security-policy": "default-src 'self' https://www.moistflap.com; script-src 'self' https://www.google-analytics.com https://cdn.ampproject.org; style-src 'self' https://www.moistflap.com 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; connect-src https://www.google-analytics.com https://cdn.ampproject.org https://www.googletagmanager.com",
+        "content-security-policy": "default-src 'self' https://www.moistflap.com; script-src 'self' https://www.google-analytics.com https://www.googletagmanager.com; style-src 'self' https://www.moistflap.com 'unsafe-inline'; img-src 'self' https://www.google-analytics.com; connect-src https://www.google-analytics.com https://www.googletagmanager.com",
         "x-frame-options": "DENY"
     },
     "mimeTypes": {}


### PR DESCRIPTION
AMP disallowed the custom JS needed to pick a random background gif
on each load. main.js now picks randomly from a list (currently
flap.gif, with flap-rain.gif as a planned addition) and falls back
to flap.gif if a listed file is missing. Restores the lightweight
flap.png poster while the chosen gif loads.